### PR TITLE
Removing namespace from deployment manifest

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -4,7 +4,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo-service
-  namespace: keptn
 spec:
   selector:
     matchLabels:
@@ -65,7 +64,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: echo-service
-  namespace: keptn
   labels:
     app.kubernetes.io/name: shipyard-controller
     app.kubernetes.io/instance: keptn


### PR DESCRIPTION
This PR removes the namespace from deployment manifest.

This is necessary such that you can install echo-service to any other kubernetes namespace.